### PR TITLE
fix: agent-js Ed25519KeyIdentity.generate() generate similar principal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@junobuild/cli",
-  "version": "0.0.50",
+  "version": "0.0.51",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@junobuild/cli",
-      "version": "0.0.50",
+      "version": "0.0.51",
       "license": "MIT",
       "dependencies": {
         "@dfinity/agent": "^0.20.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@junobuild/cli",
-  "version": "0.0.50",
+  "version": "0.0.51",
   "description": "The Juno command-line interface",
   "author": "David Dal Busco (https://daviddalbusco.com)",
   "license": "MIT",

--- a/src/services/login.services.ts
+++ b/src/services/login.services.ts
@@ -21,7 +21,7 @@ export const login = async (args?: string[]) => {
   const port = await getPort();
   const nonce = Math.floor(Math.random() * (2 << 29) + 1);
 
-  const key = Ed25519KeyIdentity.generate();
+  const key = Ed25519KeyIdentity.generate(null as unknown as Uint8Array);
   const principal = key.getPrincipal().toText();
   const token = key.toJSON(); // save to local
 


### PR DESCRIPTION
There is a bug in agent-js introduced in v0.20.1 which leads `Ed25519KeyIdentity.generate()` to always generate the same principal `535yc-uxytb-gfk7h-tny7p-vjkoe-i4krp-3qmcl-uqfgr-cpgej-yqtjq-rqe`.

This PR was manually released as a hotfix in [v0.0.51](https://github.com/junobuild/cli/releases/tag/v0.0.51).

CLI version >= v0.0.44 <= v0.0.50 have been deprecated.