### PR TITLE
feat: redo generate without arguments

### DIFF
--- a/src/services/login.services.ts
+++ b/src/services/login.services.ts
@@ -21,7 +21,7 @@ export const login = async (args?: string[]) => {
   const port = await getPort();
   const nonce = Math.floor(Math.random() * (2 << 29) + 1);
 
-  const key = Ed25519KeyIdentity.generate(null as unknown as Uint8Array);
+  const key = Ed25519KeyIdentity.generate();
   const principal = key.getPrincipal().toText();
   const token = key.toJSON(); // save to local
 


### PR DESCRIPTION
According [security advisory](https://github.com/advisories/GHSA-c9vv-fhgv-cjc3) it's safer for the future, once agent-js patched, to use generate without arguments and not the workaround.