### PR TITLE
feat: ic-wasm --keep-name-section

### DIFF
--- a/src/services/build.services.ts
+++ b/src/services/build.services.ts
@@ -187,7 +187,13 @@ const icWasm = async () => {
   // Remove unused functions and debug info.
   await spawn({
     command: 'ic-wasm',
-    args: [join(CARGO_RELEASE_DIR, 'satellite.wasm'), '-o', SATELLITE_OUTPUT, 'shrink', '--keep-name-section']
+    args: [
+      join(CARGO_RELEASE_DIR, 'satellite.wasm'),
+      '-o',
+      SATELLITE_OUTPUT,
+      'shrink',
+      '--keep-name-section'
+    ]
   });
 
   // Adds the content of satellite.did to the `icp:public candid:service` custom section of the public metadata in the wasm

--- a/src/services/build.services.ts
+++ b/src/services/build.services.ts
@@ -187,7 +187,7 @@ const icWasm = async () => {
   // Remove unused functions and debug info.
   await spawn({
     command: 'ic-wasm',
-    args: [join(CARGO_RELEASE_DIR, 'satellite.wasm'), '-o', SATELLITE_OUTPUT, 'shrink']
+    args: [join(CARGO_RELEASE_DIR, 'satellite.wasm'), '-o', SATELLITE_OUTPUT, 'shrink', '--keep-name-section']
   });
 
   // Adds the content of satellite.did to the `icp:public candid:service` custom section of the public metadata in the wasm
@@ -202,7 +202,8 @@ const icWasm = async () => {
       '-f',
       SATELLITE_DID_FILE,
       '-v',
-      'public'
+      'public',
+      '--keep-name-section'
     ]
   });
 
@@ -218,7 +219,8 @@ const icWasm = async () => {
       '-d',
       'extended',
       '-v',
-      'public'
+      'public',
+      '--keep-name-section'
     ]
   });
 
@@ -234,7 +236,8 @@ const icWasm = async () => {
       '-d',
       '"1,2"',
       '-v',
-      'public'
+      'public',
+      '--keep-name-section'
     ]
   });
 };


### PR DESCRIPTION
We need to add `--keep-name-section` to `ic-wasm` if we want to enjoy the upcoming "Canister Backtraces" feature

Source: https://forum.dfinity.org/t/canister-backtraces/35298/9?u=peterparker