### PR TITLE
feat: cache agent

### DIFF
--- a/src/api/agent.api.ts
+++ b/src/api/agent.api.ts
@@ -1,23 +1,56 @@
 import {HttpAgent} from '@dfinity/agent';
-import {nonNullish} from '@junobuild/utils';
+import type {ActorParameters} from '@junobuild/admin';
+import {isNullish, nonNullish} from '@junobuild/utils';
+import {REVOKED_CONTROLLERS} from '../constants/constants';
 import {actorParameters} from './actor.api';
 
-export const initAgent = async (): Promise<HttpAgent> => {
-  const {identity, container, fetch} = await actorParameters();
+export class AgentApi {
+  #agents: Record<string, HttpAgent> | undefined = undefined;
 
-  const localActor = nonNullish(container) && container !== false;
+  async getAgent({identity, ...rest}: Omit<ActorParameters, 'agent'>): Promise<HttpAgent> {
+    const key = identity.getPrincipal().toText();
 
-  const host = localActor
-    ? container === true
-      ? 'http://127.0.0.1:5987'
-      : container
-    : 'https://icp-api.io';
+    if (isNullish(this.#agents) || isNullish(this.#agents[key])) {
+      const agent = await this.createAgent({identity, ...rest});
 
-  return await HttpAgent.create({
-    identity,
-    host,
-    retryTimes: 10,
-    fetch,
-    shouldFetchRootKey: localActor
-  });
+      this.#agents = {
+        ...(this.#agents ?? {}),
+        [key]: agent
+      };
+
+      return agent;
+    }
+
+    return this.#agents[key];
+  }
+
+  private async createAgent({identity, container, fetch}: ActorParameters): Promise<HttpAgent> {
+    const localActor = nonNullish(container) && container !== false;
+
+    const host = localActor
+      ? container === true
+        ? 'http://127.0.0.1:5987'
+        : container
+      : 'https://icp-api.io';
+
+    return await HttpAgent.create({
+      identity,
+      host,
+      retryTimes: 10,
+      fetch,
+      shouldFetchRootKey: localActor
+    });
+  }
+}
+
+const agent = new AgentApi();
+
+export const initAgent = async (params?: Omit<ActorParameters, 'agent'>): Promise<HttpAgent> => {
+  const {identity, ...rest} = params ?? (await actorParameters());
+
+  if (REVOKED_CONTROLLERS.includes(identity.getPrincipal().toText())) {
+    throw new Error('The controller has been revoked for security reason!');
+  }
+
+  return await agent.getAgent({identity, ...rest});
 };


### PR DESCRIPTION
The agent is doing all kinds of stuffs on create therefore it's probably best to cache it when we use it.

Note that this improvement leverage another improvement in the admin library which allow to pass a specific agent.