### PR TITLE
feat: remove option --nocheck

### DIFF
--- a/src/help/upgrade.help.ts
+++ b/src/help/upgrade.help.ts
@@ -10,7 +10,6 @@ Options:
   ${yellow('-t, --target')}          Which module type should be upgraded? Valid targets are ${magenta('satellite')}, ${magenta('mission-control')} or ${magenta('orbiter')}.  
   ${yellow('-s, --src')}             An optional local gzipped WASM file for the upgrade. By default, the CDN will be used.
   ${yellow('-r, --reset')}           Reset to the initial state.
-  ${yellow('-n, --nocheck')}         Skip assertions and execute upgrade without prompts.
   ${yellow('-c, --clear-chunks')}    Clear any previously uploaded WASM chunks (applies if the WASM size is greater than 2MB).
   ${helpMode}
   ${yellow('-h, --help')}            Output usage information.

--- a/src/services/upgrade/upgrade.mission-control.services.ts
+++ b/src/services/upgrade/upgrade.mission-control.services.ts
@@ -77,7 +77,6 @@ const updateMissionControlRelease = async ({
     return {success: false};
   }
 
-  const nocheck = hasArgs({args, options: ['-n', '--nocheck']});
   const preClearChunks = hasArgs({args, options: ['-c', '--clear-chunks']});
 
   const upgradeMissionControlWasm = async (params: UpgradeWasmModule) => {
@@ -90,7 +89,6 @@ const updateMissionControlRelease = async ({
 
   return await upgradeWasmCdn({
     version,
-    nocheck,
     assetKey: 'mission_control',
     upgrade: upgradeMissionControlWasm
   });
@@ -110,7 +108,6 @@ const upgradeMissionControlCustom = async ({
     return {success: false};
   }
 
-  const nocheck = hasArgs({args, options: ['-n', '--nocheck']});
   const preClearChunks = hasArgs({args, options: ['-c', '--clear-chunks']});
 
   const upgradeMissionControlWasm = async (params: UpgradeWasmModule) => {
@@ -123,7 +120,6 @@ const upgradeMissionControlCustom = async ({
 
   return await upgradeWasmLocal({
     src,
-    nocheck,
     assetKey: 'mission_control',
     upgrade: upgradeMissionControlWasm
   });

--- a/src/services/upgrade/upgrade.orbiter.services.ts
+++ b/src/services/upgrade/upgrade.orbiter.services.ts
@@ -71,7 +71,6 @@ const upgradeOrbiterCustom = async ({
 
   const reset = await confirmReset({args, assetKey: 'orbiter'});
 
-  const nocheck = hasArgs({args, options: ['-n', '--nocheck']});
   const preClearChunks = hasArgs({args, options: ['-c', '--clear-chunks']});
 
   const upgradeOrbiterWasm = async (params: UpgradeWasmModule) => {
@@ -85,7 +84,6 @@ const upgradeOrbiterCustom = async ({
 
   return await upgradeWasmLocal({
     src,
-    nocheck,
     assetKey: 'orbiter',
     upgrade: upgradeOrbiterWasm,
     reset
@@ -117,7 +115,6 @@ const updateOrbiterRelease = async ({
 
   const reset = await confirmReset({args, assetKey: 'orbiter'});
 
-  const nocheck = hasArgs({args, options: ['-n', '--nocheck']});
   const preClearChunks = hasArgs({args, options: ['-c', '--clear-chunks']});
 
   const upgradeOrbiterWasm = async (params: UpgradeWasmModule) => {
@@ -133,7 +130,6 @@ const updateOrbiterRelease = async ({
     version,
     assetKey: 'orbiter',
     upgrade: upgradeOrbiterWasm,
-    reset,
-    nocheck
+    reset
   });
 };

--- a/src/services/upgrade/upgrade.satellite.services.ts
+++ b/src/services/upgrade/upgrade.satellite.services.ts
@@ -76,13 +76,12 @@ const upgradeSatelliteCustom = async ({
     satellite
   });
 
-  const nocheck = hasArgs({args, options: ['-n', '--nocheck']});
   const preClearChunks = hasArgs({args, options: ['-c', '--clear-chunks']});
 
   const upgrade = async (
     params: Pick<UpgradeWasm, 'upgrade' | 'reset' | 'assert'>
   ): Promise<{success: boolean; err?: unknown}> => {
-    return await upgradeWasmLocal({src, assetKey: 'satellite', nocheck, ...params});
+    return await upgradeWasmLocal({src, assetKey: 'satellite', ...params});
   };
 
   return await executeUpgradeSatellite({
@@ -112,13 +111,12 @@ const upgradeSatelliteRelease = async ({
     return {success: false};
   }
 
-  const nocheck = hasArgs({args, options: ['-n', '--nocheck']});
   const preClearChunks = hasArgs({args, options: ['-c', '--clear-chunks']});
 
   const upgrade = async (
     params: Pick<UpgradeWasm, 'upgrade' | 'reset' | 'assert'>
   ): Promise<{success: boolean; err?: unknown}> => {
-    return await upgradeWasmCdn({version, assetKey: 'satellite', nocheck, ...params});
+    return await upgradeWasmCdn({version, assetKey: 'satellite', ...params});
   };
 
   return await executeUpgradeSatellite({

--- a/src/services/upgrade/upgrade.services.ts
+++ b/src/services/upgrade/upgrade.services.ts
@@ -18,6 +18,7 @@ import {JUNO_CDN_URL} from '../../constants/constants';
 import type {AssetKey} from '../../types/asset-key';
 import type {UpgradeWasm} from '../../types/upgrade';
 import {toAssetKeys} from '../../utils/asset-key.utils';
+import {isNotHeadless} from '../../utils/process.utils';
 import {confirmAndExit} from '../../utils/prompt.utils';
 import {newerReleases as newerReleasesUtils} from '../../utils/upgrade.utils';
 import {assertUpgradeHash} from './upgrade-assert.services';
@@ -28,10 +29,9 @@ const executeUpgradeWasm = async ({
   hash,
   assert,
   reset = false,
-  nocheck,
   assetKey
 }: {assetKey: AssetKey} & UpgradeWasm) => {
-  if (!nocheck) {
+  if (isNotHeadless()) {
     await assert?.({wasmModule: wasm});
     await assertUpgradeHash({hash, reset});
   }
@@ -70,12 +70,11 @@ export const upgradeWasmLocal = async ({
   upgrade,
   reset,
   assert,
-  nocheck,
   assetKey
 }: {
   src: string;
   assetKey: AssetKey;
-} & Pick<UpgradeWasm, 'reset' | 'upgrade' | 'assert' | 'nocheck'>): Promise<{
+} & Pick<UpgradeWasm, 'reset' | 'upgrade' | 'assert'>): Promise<{
   success: boolean;
   err?: unknown;
 }> => {
@@ -95,7 +94,7 @@ export const upgradeWasmLocal = async ({
 
     spinner.stop();
 
-    await executeUpgradeWasm({upgrade, wasm, hash, reset, assert, nocheck, assetKey});
+    await executeUpgradeWasm({upgrade, wasm, hash, reset, assert, assetKey});
 
     return {success: true};
   } catch (err: unknown) {
@@ -110,12 +109,11 @@ export const upgradeWasmCdn = async ({
   assetKey,
   upgrade,
   assert,
-  reset,
-  nocheck
+  reset
 }: {
   version: string;
   assetKey: AssetKey;
-} & Pick<UpgradeWasm, 'reset' | 'upgrade' | 'assert' | 'nocheck'>): Promise<{
+} & Pick<UpgradeWasm, 'reset' | 'upgrade' | 'assert'>): Promise<{
   success: boolean;
   err?: unknown;
 }> => {
@@ -143,7 +141,7 @@ export const upgradeWasmCdn = async ({
 
     spinner.stop();
 
-    await executeUpgradeWasm({upgrade, wasm, hash, reset, assert, nocheck, assetKey});
+    await executeUpgradeWasm({upgrade, wasm, hash, reset, assert, assetKey});
 
     return {success: true};
   } catch (err: unknown) {

--- a/src/types/upgrade.ts
+++ b/src/types/upgrade.ts
@@ -11,5 +11,4 @@ export interface UpgradeWasm {
   upgrade: (params: UpgradeWasmModule) => Promise<void>;
   assert?: (params: AssertWasmModule) => Promise<void>;
   reset?: boolean;
-  nocheck: boolean;
 }

--- a/src/utils/process.utils.ts
+++ b/src/utils/process.utils.ts
@@ -26,3 +26,5 @@ export const isHeadless = (): boolean => {
   const [_, ...args] = process.argv.slice(2);
   return hasArgs({args, options: ['--headless']});
 };
+
+export const isNotHeadless = (): boolean => !isHeadless();


### PR DESCRIPTION
It's a breaking change but, in the meantime we got now `--headless` which can replace `--nocheck` since that was the idea behind the check.