### PR TITLE
feat: -cc

### DIFF
--- a/src/help/upgrade.help.ts
+++ b/src/help/upgrade.help.ts
@@ -10,7 +10,7 @@ Options:
   ${yellow('-t, --target')}          Which module type should be upgraded? Valid targets are ${magenta('satellite')}, ${magenta('mission-control')} or ${magenta('orbiter')}.  
   ${yellow('-s, --src')}             An optional local gzipped WASM file for the upgrade. By default, the CDN will be used.
   ${yellow('-r, --reset')}           Reset to the initial state.
-  ${yellow('-c, --clear-chunks')}    Clear any previously uploaded WASM chunks (applies if the WASM size is greater than 2MB).
+  ${yellow('-cc, --clear-chunks')}    Clear any previously uploaded WASM chunks (applies if the WASM size is greater than 2MB).
   ${helpMode}
   ${yellow('-h, --help')}            Output usage information.
   

--- a/src/services/upgrade/upgrade.mission-control.services.ts
+++ b/src/services/upgrade/upgrade.mission-control.services.ts
@@ -77,7 +77,7 @@ const updateMissionControlRelease = async ({
     return {success: false};
   }
 
-  const preClearChunks = hasArgs({args, options: ['-c', '--clear-chunks']});
+  const preClearChunks = hasArgs({args, options: ['-cc', '--clear-chunks']});
 
   const upgradeMissionControlWasm = async (params: UpgradeWasmModule) => {
     await upgradeMissionControlAdmin({
@@ -108,7 +108,7 @@ const upgradeMissionControlCustom = async ({
     return {success: false};
   }
 
-  const preClearChunks = hasArgs({args, options: ['-c', '--clear-chunks']});
+  const preClearChunks = hasArgs({args, options: ['-cc', '--clear-chunks']});
 
   const upgradeMissionControlWasm = async (params: UpgradeWasmModule) => {
     await upgradeMissionControlAdmin({

--- a/src/services/upgrade/upgrade.orbiter.services.ts
+++ b/src/services/upgrade/upgrade.orbiter.services.ts
@@ -71,7 +71,7 @@ const upgradeOrbiterCustom = async ({
 
   const reset = await confirmReset({args, assetKey: 'orbiter'});
 
-  const preClearChunks = hasArgs({args, options: ['-c', '--clear-chunks']});
+  const preClearChunks = hasArgs({args, options: ['-cc', '--clear-chunks']});
 
   const upgradeOrbiterWasm = async (params: UpgradeWasmModule) => {
     await upgradeOrbiterAdmin({
@@ -115,7 +115,7 @@ const updateOrbiterRelease = async ({
 
   const reset = await confirmReset({args, assetKey: 'orbiter'});
 
-  const preClearChunks = hasArgs({args, options: ['-c', '--clear-chunks']});
+  const preClearChunks = hasArgs({args, options: ['-cc', '--clear-chunks']});
 
   const upgradeOrbiterWasm = async (params: UpgradeWasmModule) => {
     await upgradeOrbiterAdmin({

--- a/src/services/upgrade/upgrade.satellite.services.ts
+++ b/src/services/upgrade/upgrade.satellite.services.ts
@@ -76,7 +76,7 @@ const upgradeSatelliteCustom = async ({
     satellite
   });
 
-  const preClearChunks = hasArgs({args, options: ['-c', '--clear-chunks']});
+  const preClearChunks = hasArgs({args, options: ['-cc', '--clear-chunks']});
 
   const upgrade = async (
     params: Pick<UpgradeWasm, 'upgrade' | 'reset' | 'assert'>
@@ -111,7 +111,7 @@ const upgradeSatelliteRelease = async ({
     return {success: false};
   }
 
-  const preClearChunks = hasArgs({args, options: ['-c', '--clear-chunks']});
+  const preClearChunks = hasArgs({args, options: ['-cc', '--clear-chunks']});
 
   const upgrade = async (
     params: Pick<UpgradeWasm, 'upgrade' | 'reset' | 'assert'>


### PR DESCRIPTION
It's a bit ugly but using `-cc` instead of `-c` for `--clear-chunks` can help avoid name clashes. It can be a new pattern.