### PR TITLE
feat: replace core-peer by core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@junobuild/admin": "^0.0.61",
         "@junobuild/cli-tools": "^0.0.16",
         "@junobuild/config-loader": "^0.0.7",
-        "@junobuild/core-peer": "^0.0.29",
+        "@junobuild/core": "^0.1.0",
         "@junobuild/did-tools": "^0.0.4",
         "@junobuild/utils": "^0.0.27",
         "conf": "^13.0.1",
@@ -1382,10 +1382,10 @@
         "@junobuild/utils": "*"
       }
     },
-    "node_modules/@junobuild/core-peer": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@junobuild/core-peer/-/core-peer-0.0.29.tgz",
-      "integrity": "sha512-sld/xXCGrPv6WeamRfY0beENnzaKmTo3ZqIZNDjkkigH1YJUEvR1vxuW5gL3WCjJpYafBeZi6lB3Re4syKJzfg==",
+    "node_modules/@junobuild/core": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@junobuild/core/-/core-0.1.0.tgz",
+      "integrity": "sha512-m2p1ahm660S8Jdlo5GCOZigz5Rr9FD+3Yh1JSsLx9LkmBoBi83kwi0uVIq8TOyDpuwHtIHCXsw/rwtr8EoD7UA==",
       "license": "MIT",
       "dependencies": {
         "@junobuild/storage": "*",
@@ -1394,6 +1394,7 @@
       "peerDependencies": {
         "@dfinity/agent": "^2.1.3",
         "@dfinity/auth-client": "^2.1.3",
+        "@dfinity/candid": "^2.1.3",
         "@dfinity/identity": "^2.1.3",
         "@dfinity/principal": "^2.1.3"
       }
@@ -1414,9 +1415,9 @@
       }
     },
     "node_modules/@junobuild/storage": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@junobuild/storage/-/storage-0.0.7.tgz",
-      "integrity": "sha512-p+XrFJUt0nI8j34ljfMjbdSJrBFgwOOmbDowWujPotHq7FCYRuowkkATAfmgo1lIw2y1THuiQwVfiqg1Ey7L6A==",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@junobuild/storage/-/storage-0.0.8.tgz",
+      "integrity": "sha512-95ANZNuBv+igf1oX6iuyNiBex8wbVfIaHZ0Iqfq1Q4Fp30yZloY+05csOZ7ukObLDEtCvtYT2Ft1b2rd+o8GVQ==",
       "license": "MIT",
       "peerDependencies": {
         "@dfinity/agent": "^2.1.3",
@@ -7486,10 +7487,10 @@
         "@babel/preset-typescript": "^7.24.7"
       }
     },
-    "@junobuild/core-peer": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@junobuild/core-peer/-/core-peer-0.0.29.tgz",
-      "integrity": "sha512-sld/xXCGrPv6WeamRfY0beENnzaKmTo3ZqIZNDjkkigH1YJUEvR1vxuW5gL3WCjJpYafBeZi6lB3Re4syKJzfg==",
+    "@junobuild/core": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@junobuild/core/-/core-0.1.0.tgz",
+      "integrity": "sha512-m2p1ahm660S8Jdlo5GCOZigz5Rr9FD+3Yh1JSsLx9LkmBoBi83kwi0uVIq8TOyDpuwHtIHCXsw/rwtr8EoD7UA==",
       "requires": {
         "@junobuild/storage": "*",
         "@junobuild/utils": "*"
@@ -7507,9 +7508,9 @@
       }
     },
     "@junobuild/storage": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@junobuild/storage/-/storage-0.0.7.tgz",
-      "integrity": "sha512-p+XrFJUt0nI8j34ljfMjbdSJrBFgwOOmbDowWujPotHq7FCYRuowkkATAfmgo1lIw2y1THuiQwVfiqg1Ey7L6A==",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@junobuild/storage/-/storage-0.0.8.tgz",
+      "integrity": "sha512-95ANZNuBv+igf1oX6iuyNiBex8wbVfIaHZ0Iqfq1Q4Fp30yZloY+05csOZ7ukObLDEtCvtYT2Ft1b2rd+o8GVQ==",
       "requires": {}
     },
     "@junobuild/utils": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@junobuild/admin": "^0.0.61",
     "@junobuild/cli-tools": "^0.0.16",
     "@junobuild/config-loader": "^0.0.7",
-    "@junobuild/core-peer": "^0.0.29",
+    "@junobuild/core": "^0.1.0",
     "@junobuild/did-tools": "^0.0.4",
     "@junobuild/utils": "^0.0.27",
     "conf": "^13.0.1",

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -5,7 +5,7 @@ import {
   preDeploy as cliPreDeploy,
   hasArgs
 } from '@junobuild/cli-tools';
-import {uploadBlob, type Asset} from '@junobuild/core-peer';
+import {uploadBlob, type Asset} from '@junobuild/core';
 import {red} from 'kleur';
 import {lstatSync} from 'node:fs';
 import {junoConfigExist, readJunoConfig} from '../configs/juno.config';

--- a/src/services/build.services.ts
+++ b/src/services/build.services.ts
@@ -188,9 +188,7 @@ const api = async () => {
     try {
       const packageJson = await readFile(join(process.cwd(), 'package.json'), 'utf-8');
       const {dependencies} = JSON.parse(packageJson) as {dependencies?: Record<string, string>};
-      return Object.keys(dependencies ?? {}).includes('@junobuild/core-peer')
-        ? 'core-peer'
-        : 'core';
+      return Object.keys(dependencies ?? {}).includes('@junobuild/core') ? 'core-peer' : 'core';
     } catch (err: unknown) {
       // This should not block the developer therefore we fallback to core
       return 'core';

--- a/src/services/clear.services.ts
+++ b/src/services/clear.services.ts
@@ -1,5 +1,5 @@
 import {deleteAssets, listCustomDomains, setCustomDomains} from '@junobuild/admin';
-import {deleteAsset} from '@junobuild/core-peer';
+import {deleteAsset} from '@junobuild/core';
 import ora from 'ora';
 import {readJunoConfig} from '../configs/juno.config';
 import {DAPP_COLLECTION} from '../constants/constants';

--- a/src/services/deploy.services.ts
+++ b/src/services/deploy.services.ts
@@ -1,6 +1,6 @@
 import {satelliteMemorySize, satelliteVersion} from '@junobuild/admin';
-import type {Asset} from '@junobuild/core-peer';
-import {listAssets as listAssetsLib} from '@junobuild/core-peer';
+import type {Asset} from '@junobuild/core';
+import {listAssets as listAssetsLib} from '@junobuild/core';
 import {yellow} from 'kleur';
 import {compare} from 'semver';
 import {readJunoConfig} from '../configs/juno.config';


### PR DESCRIPTION
`core-peer` as been deprecated because `core` now inherits agent-js as peer dependencies.