### PR TITLE
chore: ignore eject template declarations and did extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ dist/
 
 target/
 templates/eject/Cargo.lock
+templates/eject/src/declarations
+templates/eject/src/satellite/satellite_extension.did


### PR DESCRIPTION
Are not shipped.