### PR TITLE
feat: juno init --minimal

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -22,14 +22,14 @@ import {NEW_CMD_LINE, confirm, confirmAndExit} from '../utils/prompt.utils';
 
 export const init = async (args?: string[]) => {
   if (hasArgs({args, options: ['-m', '--minimal']})) {
-    await initWithPlaceholder(args);
+    await initWithPlaceholder();
     return;
   }
 
   await initWithSatelliteId(args);
 };
 
-const initWithPlaceholder = async (args?: string[]) => {
+const initWithPlaceholder = async () => {
   await assertOverwrite();
 
   await initConfigNoneInteractive();

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,5 +1,5 @@
 import {isNullish, nonNullish} from '@dfinity/utils';
-import {assertAnswerCtrlC} from '@junobuild/cli-tools';
+import {assertAnswerCtrlC, hasArgs} from '@junobuild/cli-tools';
 import type {PartialConfigFile} from '@junobuild/config-loader';
 import {cyan, yellow} from 'kleur';
 import {unlink} from 'node:fs/promises';
@@ -10,15 +10,32 @@ import {
   detectJunoConfigType,
   junoConfigExist,
   junoConfigFile,
-  writeJunoConfig
+  writeJunoConfig,
+  writeJunoConfigPlaceholder
 } from '../configs/juno.config';
 import {promptConfigType} from '../services/init.services';
 import {login as consoleLogin} from '../services/login.services';
 import type {CliOrbiterConfig, CliSatelliteConfig} from '../types/cli.config';
+import type {PackageManager} from '../types/pm';
 import {detectPackageManager} from '../utils/pm.utils';
 import {NEW_CMD_LINE, confirm, confirmAndExit} from '../utils/prompt.utils';
 
 export const init = async (args?: string[]) => {
+  if (hasArgs({args, options: ['-m', '--minimal']})) {
+    await initWithPlaceholder(args);
+    return;
+  }
+
+  await initWithSatelliteId(args);
+};
+
+const initWithPlaceholder = async (args?: string[]) => {
+  await assertOverwrite();
+
+  await initConfigNoneInteractive();
+};
+
+const initWithSatelliteId = async (args?: string[]) => {
   const token = await getToken();
 
   if (isNullish(token)) {
@@ -33,33 +50,67 @@ export const init = async (args?: string[]) => {
     await consoleLogin(args);
   }
 
+  await assertOverwrite();
+
+  await initConfigInteractive();
+};
+
+const assertOverwrite = async () => {
   if (await junoConfigExist()) {
     await confirmAndExit(
       'Your existing configuration will be overwritten. Are you sure you want to continue?'
     );
   }
-
-  await initConfig();
 };
 
-const initConfig = async () => {
+const initConfigNoneInteractive = async () => {
+  const writeFn = async ({source, ...rest}: InitConfigParams) => {
+    await writeJunoConfigPlaceholder({
+      ...rest,
+      config: {
+        satellite: {source}
+      }
+    });
+  };
+
+  await initConfig({
+    writeFn
+  });
+};
+
+const initConfigInteractive = async () => {
   const satelliteId = await initSatelliteConfig();
   const orbiterId = await initOrbiterConfig();
 
+  const writeFn = async ({source, ...rest}: InitConfigParams) => {
+    await writeJunoConfig({
+      ...rest,
+      config: {
+        satellite: {id: satelliteId, source},
+        ...(nonNullish(orbiterId) && {orbiter: {id: orbiterId}})
+      }
+    });
+  };
+
+  await initConfig({
+    writeFn
+  });
+};
+
+type InitConfigParams = PartialConfigFile & {pm: PackageManager | undefined} & {source: string};
+
+const initConfig = async ({writeFn}: {writeFn: (params: InitConfigParams) => Promise<void>}) => {
   const source = await promptSource();
 
   const {configType, configPath: originalConfigPath} = await initConfigType();
 
   const pm = detectPackageManager();
 
-  await writeJunoConfig({
-    config: {
-      satellite: {id: satelliteId, source},
-      ...(nonNullish(orbiterId) && {orbiter: {id: orbiterId}})
-    },
+  await writeFn({
     configType,
     configPath: originalConfigPath,
-    pm
+    pm,
+    source
   });
 
   // We delete the deprecated juno.json, which is now replaced with juno.config.json|ts|js, as just created above.

--- a/src/help/init.help.ts
+++ b/src/help/init.help.ts
@@ -1,7 +1,31 @@
-import {logHelp} from './generic.help';
+import {cyan, green, yellow} from 'kleur';
+import {helpMode, helpOutput} from './common.help';
+import {TITLE} from './help';
+import {OPEN_DESCRIPTION} from './open.help';
 
 export const INIT_DESCRIPTION = 'Set up your project.';
 
+const usage = `Usage: ${green('juno')} ${cyan('init')} ${yellow('[options]')}
+
+Options:
+  ${yellow('-m, --minimal')}         Skip few prompts and generate a config file with a placeholder satellite ID.
+  ${helpMode}
+  ${yellow('-h, --help')}            Output usage information.`;
+
+const doc = `${OPEN_DESCRIPTION}
+
+\`\`\`bash
+${usage}
+\`\`\`
+`;
+
+const help = `${TITLE}
+
+${OPEN_DESCRIPTION}
+
+${usage}
+`;
+
 export const logHelpInit = (args?: string[]) => {
-  logHelp({args, command: 'init', description: INIT_DESCRIPTION});
+  console.log(helpOutput(args) === 'doc' ? doc : help);
 };

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -9,3 +9,7 @@ export type JunoConfigWithSatelliteId = Omit<JunoConfig, 'satellite' | 'orbiter'
   satellite: Omit<SatelliteConfig, 'id' | 'satellitesIds'> & Required<Pick<SatelliteConfig, 'id'>>;
   orbiter?: Omit<OrbiterConfig, 'orbiterId'>;
 };
+
+export type JunoConfigWithPlaceholder = Omit<JunoConfig, 'satellite' | 'orbiter'> & {
+  satellite: Pick<SatelliteConfig, 'source'>;
+};


### PR DESCRIPTION
A new option for `juno init` which just generates the config with a placeholder. Useful when following the GitHub Actions tutorial.