### PR TITLE
feat: init settings when required and not globally

### DIFF
--- a/src/configs/cli.config.ts
+++ b/src/configs/cli.config.ts
@@ -5,7 +5,7 @@ import {nonNullish} from '@dfinity/utils';
 import type Conf from 'conf';
 import {red, yellow} from 'kleur';
 import {askForPassword} from '../services/cli.settings.services';
-import {settingsStore} from '../stores/settings.store';
+import {getSettingsStore} from '../stores/settings.store';
 import type {
   CliConfig,
   CliConfigData,
@@ -23,6 +23,8 @@ const initConfig = async () => {
   if (nonNullish(config)) {
     return;
   }
+
+  const settingsStore = await getSettingsStore();
 
   const encryptionKey = settingsStore.isEncryptionEnabled() ? await askForPassword() : undefined;
 


### PR DESCRIPTION
When a new user install the CLI, they might just use `juno --version` or just use it to start the local development environment `juno dev start`. In that case, it does not make sense to ask to encode the config since those commands do not require one.