### PR TITLE
fix: minimal version of ic-wasm is v0.8.5

### DIFF
--- a/src/constants/dev.constants.ts
+++ b/src/constants/dev.constants.ts
@@ -12,5 +12,5 @@ export const TEMPLATE_PATH = '../templates/eject';
 export const TEMPLATE_SATELLITE_PATH = join(TEMPLATE_PATH, 'src', 'satellite');
 
 export const RUST_MIN_VERSION = '1.70.0';
-export const IC_WASM_MIN_VERSION = '0.3.6';
+export const IC_WASM_MIN_VERSION = '0.8.5';
 export const DOCKER_MIN_VERSION = '24.0.0';


### PR DESCRIPTION
As reported today on [Discord](https://discord.com/channels/1076791076544847982/1344599110660915271/1344908738393542699), we added `--keep-name-section` to support canister backtraces but, this requires at least `ic-wasm@0.8.5`  but, the CLI was still checking for a lower version.

```
Error: error: unexpected argument '--keep-name-section' found
```
