### PR TITLE
feat: remove bun detection

### DIFF
--- a/src/types/pm.ts
+++ b/src/types/pm.ts
@@ -1,1 +1,1 @@
-export type PackageManager = 'npm' | 'yarn' | 'pnpm' | 'bun';
+export type PackageManager = 'npm' | 'yarn' | 'pnpm';

--- a/src/utils/pm.utils.ts
+++ b/src/utils/pm.utils.ts
@@ -15,12 +15,6 @@ export const detectPackageManager = (): PackageManager | undefined => {
     return 'yarn';
   }
 
-  const bun = join(process.cwd(), 'bun.lockb');
-
-  if (existsSync(bun)) {
-    return 'bun';
-  }
-
   const npm = join(process.cwd(), 'package-lock.json');
 
   if (existsSync(npm)) {


### PR DESCRIPTION
Bun is not a package manaer. Let's review this later in #201, meanwhile let's not detect it as it would for example generate a `predeploy [bun build]` command which is actually invalid.