### PR TITLE
fix: recursive imports by constants

### DIFF
--- a/src/constants/help.constants.ts
+++ b/src/constants/help.constants.ts
@@ -1,0 +1,20 @@
+export const CLEAR_DESCRIPTION =
+  'Clear existing dapp code by removing JavaScript, HTML, CSS, and other files from your satellite.';
+export const CONFIG_DESCRIPTION = 'Apply configuration to satellite.';
+export const DEPLOY_DESCRIPTION = 'Deploy your dapp to your satellite.';
+export const DEV_DESCRIPTION =
+  'Handle development tasks like building serverless functions or running a local Internet Computer instance.';
+export const INIT_DESCRIPTION = 'Set up your project.';
+export const LOGIN_DESCRIPTION =
+  'Generate an authentication for use in non-interactive environments.';
+export const LOGOUT_DESCRIPTION =
+  'Log out of the current device. ⚠️  This action does not remove controllers from the module.';
+export const OPEN_DESCRIPTION = 'Open your satellite in your browser.';
+export const SNAPSHOT_DESCRIPTION = 'Handle snapshot-related tasks.';
+export const START_DESCRIPTION = 'Start a module.';
+export const STOP_DESCRIPTION = 'Stop a module.';
+export const UPGRADE_DESCRIPTION = 'Upgrade a module to a new version.';
+export const USE_DESCRIPTION = 'Switch between multiple profiles.';
+export const VERSION_DESCRIPTION = 'Check the version of the modules and CLI.';
+export const WHOAMI_DESCRIPTION =
+  'Display your current profile, controller, and links to your satellite.';

--- a/src/help/clear.help.ts
+++ b/src/help/clear.help.ts
@@ -1,9 +1,7 @@
 import {cyan, green, yellow} from 'kleur';
+import {CLEAR_DESCRIPTION} from '../constants/help.constants';
 import {helpMode, helpOutput} from './common.help';
 import {TITLE} from './help';
-
-export const CLEAR_DESCRIPTION =
-  'Clear existing dapp code by removing JavaScript, HTML, CSS, and other files from your satellite.';
 
 const usage = `Usage: ${green('juno')} ${cyan('clear')} ${yellow('[options]')}
 

--- a/src/help/config.help.ts
+++ b/src/help/config.help.ts
@@ -1,8 +1,7 @@
 import {cyan, green, yellow} from 'kleur';
+import {CONFIG_DESCRIPTION} from '../constants/help.constants';
 import {helpMode, helpOutput} from './common.help';
 import {TITLE} from './help';
-
-export const CONFIG_DESCRIPTION = 'Apply configuration to satellite.';
 
 const usage = `Usage: ${green('juno')} ${cyan('config')} ${yellow('[options]')}
 

--- a/src/help/deploy.help.ts
+++ b/src/help/deploy.help.ts
@@ -1,8 +1,7 @@
 import {cyan, green, yellow} from 'kleur';
+import {DEPLOY_DESCRIPTION} from '../constants/help.constants';
 import {helpMode, helpOutput} from './common.help';
 import {TITLE} from './help';
-
-export const DEPLOY_DESCRIPTION = 'Deploy your dapp to your satellite.';
 
 const usage = `Usage: ${green('juno')} ${cyan('deploy')} ${yellow('[options]')}
 

--- a/src/help/dev.help.ts
+++ b/src/help/dev.help.ts
@@ -1,9 +1,7 @@
 import {cyan, green, magenta, yellow} from 'kleur';
+import {DEV_DESCRIPTION} from '../constants/help.constants';
 import {helpOutput} from './common.help';
 import {TITLE} from './help';
-
-export const DEV_DESCRIPTION =
-  'Handle development tasks like building serverless functions or running a local Internet Computer instance.';
 
 const helpDevStart = `${magenta(
   'start'

--- a/src/help/help.ts
+++ b/src/help/help.ts
@@ -1,20 +1,22 @@
 import {cyan, green, grey} from 'kleur';
 import {version} from '../../package.json';
-import {CLEAR_DESCRIPTION} from './clear.help';
-import {CONFIG_DESCRIPTION} from './config.help';
-import {DEPLOY_DESCRIPTION} from './deploy.help';
-import {DEV_DESCRIPTION} from './dev.help';
-import {INIT_DESCRIPTION} from './init.help';
-import {LOGIN_DESCRIPTION} from './login.help';
-import {LOGOUT_DESCRIPTION} from './logout.help';
-import {OPEN_DESCRIPTION} from './open.help';
-import {SNAPSHOT_DESCRIPTION} from './snapshot.help';
-import {START_DESCRIPTION} from './start.help';
-import {STOP_DESCRIPTION} from './stop.help';
-import {UPGRADE_DESCRIPTION} from './upgrade.help';
-import {USE_DESCRIPTION} from './use.help';
-import {VERSION_DESCRIPTION} from './version.help';
-import {WHOAMI_DESCRIPTION} from './whoami.help';
+import {
+  CLEAR_DESCRIPTION,
+  CONFIG_DESCRIPTION,
+  DEPLOY_DESCRIPTION,
+  DEV_DESCRIPTION,
+  INIT_DESCRIPTION,
+  LOGIN_DESCRIPTION,
+  LOGOUT_DESCRIPTION,
+  OPEN_DESCRIPTION,
+  SNAPSHOT_DESCRIPTION,
+  START_DESCRIPTION,
+  STOP_DESCRIPTION,
+  UPGRADE_DESCRIPTION,
+  USE_DESCRIPTION,
+  VERSION_DESCRIPTION,
+  WHOAMI_DESCRIPTION
+} from '../constants/help.constants';
 
 const JUNO_LOGO = `  __  __ __  __  _  ____ 
 __) ||  |  ||  \\| |/    \\

--- a/src/help/init.help.ts
+++ b/src/help/init.help.ts
@@ -1,8 +1,7 @@
 import {cyan, green, yellow} from 'kleur';
+import {INIT_DESCRIPTION} from '../constants/help.constants';
 import {helpMode, helpOutput} from './common.help';
 import {TITLE} from './help';
-
-export const INIT_DESCRIPTION = 'Set up your project.';
 
 const usage = `Usage: ${green('juno')} ${cyan('init')} ${yellow('[options]')}
 

--- a/src/help/login.help.ts
+++ b/src/help/login.help.ts
@@ -1,9 +1,7 @@
 import {cyan, green, yellow} from 'kleur';
+import {LOGIN_DESCRIPTION} from '../constants/help.constants';
 import {helpOutput} from './common.help';
 import {TITLE} from './help';
-
-export const LOGIN_DESCRIPTION =
-  'Generate an authentication for use in non-interactive environments.';
 
 const usage = `Usage: ${green('juno')} ${cyan('login')} ${yellow('[options]')}
 

--- a/src/help/logout.help.ts
+++ b/src/help/logout.help.ts
@@ -1,7 +1,5 @@
+import {LOGOUT_DESCRIPTION} from '../constants/help.constants';
 import {logHelp} from './generic.help';
-
-export const LOGOUT_DESCRIPTION =
-  'Log out of the current device. ⚠️  This action does not remove controllers from the module.';
 
 export const logHelpLogout = (args?: string[]) => {
   logHelp({args, command: 'logout', description: LOGOUT_DESCRIPTION});

--- a/src/help/open.help.ts
+++ b/src/help/open.help.ts
@@ -1,8 +1,7 @@
 import {cyan, green, yellow} from 'kleur';
+import {OPEN_DESCRIPTION} from '../constants/help.constants';
 import {helpMode, helpOutput} from './common.help';
 import {TITLE} from './help';
-
-export const OPEN_DESCRIPTION = 'Open your satellite in your browser.';
 
 const usage = `Usage: ${green('juno')} ${cyan('open')} ${yellow('[options]')}
 

--- a/src/help/snapshot.help.ts
+++ b/src/help/snapshot.help.ts
@@ -1,9 +1,8 @@
 import {cyan, green, magenta, yellow} from 'kleur';
+import {SNAPSHOT_DESCRIPTION} from '../constants/help.constants';
 import {helpMode, helpOutput} from './common.help';
 import {TITLE} from './help';
 import {TARGET_OPTION_NOTE, targetOption} from './target.help';
-
-export const SNAPSHOT_DESCRIPTION = 'Handle snapshot-related tasks.';
 
 const usage = `Usage: ${green('juno')} ${cyan('snapshot')} ${magenta('<subcommand>')} ${yellow('[options]')}
 

--- a/src/help/start.help.ts
+++ b/src/help/start.help.ts
@@ -1,8 +1,7 @@
 import {cyan, green, magenta, yellow} from 'kleur';
+import {START_DESCRIPTION} from '../constants/help.constants';
 import {helpMode, helpOutput} from './common.help';
 import {TITLE} from './help';
-
-export const START_DESCRIPTION = 'Start a module.';
 
 const usage = `Usage: ${green('juno')} ${cyan('start')} ${yellow('[options]')}
 

--- a/src/help/stop.help.ts
+++ b/src/help/stop.help.ts
@@ -1,8 +1,7 @@
 import {cyan, green, magenta, yellow} from 'kleur';
+import {STOP_DESCRIPTION} from '../constants/help.constants';
 import {helpMode, helpOutput} from './common.help';
 import {TITLE} from './help';
-
-export const STOP_DESCRIPTION = 'Stop a module.';
 
 const usage = `Usage: ${green('juno')} ${cyan('stop')} ${yellow('[options]')}
 

--- a/src/help/upgrade.help.ts
+++ b/src/help/upgrade.help.ts
@@ -1,9 +1,8 @@
 import {cyan, green, yellow} from 'kleur';
+import {UPGRADE_DESCRIPTION} from '../constants/help.constants';
 import {helpMode, helpOutput} from './common.help';
 import {TITLE} from './help';
 import {TARGET_OPTION_NOTE, targetOption} from './target.help';
-
-export const UPGRADE_DESCRIPTION = 'Upgrade a module to a new version.';
 
 const usage = `Usage: ${green('juno')} ${cyan('upgrade')} ${yellow('[options]')}
 

--- a/src/help/use.help.ts
+++ b/src/help/use.help.ts
@@ -1,8 +1,7 @@
 import {cyan, green, yellow} from 'kleur';
+import {USE_DESCRIPTION} from '../constants/help.constants';
 import {helpOutput} from './common.help';
 import {TITLE} from './help';
-
-export const USE_DESCRIPTION = 'Switch between multiple profiles.';
 
 const usage = `Usage: ${green('juno')} ${cyan('use')} ${yellow('[options]')}
 

--- a/src/help/version.help.ts
+++ b/src/help/version.help.ts
@@ -1,8 +1,7 @@
 import {cyan, green, yellow} from 'kleur';
+import {VERSION_DESCRIPTION} from '../constants/help.constants';
 import {helpMode, helpOutput} from './common.help';
 import {TITLE} from './help';
-
-export const VERSION_DESCRIPTION = 'Check the version of the modules and CLI.';
 
 const usage = `Usage: ${green('juno')} ${cyan('init')} ${yellow('[options]')}
 

--- a/src/help/whoami.help.ts
+++ b/src/help/whoami.help.ts
@@ -1,7 +1,5 @@
+import {WHOAMI_DESCRIPTION} from '../constants/help.constants';
 import {logHelpWithMode} from './generic.help';
-
-export const WHOAMI_DESCRIPTION =
-  'Display your current profile, controller, and links to your satellite.';
 
 export const logHelpWhoAmI = (args?: string[]) => {
   logHelpWithMode({args, command: 'whoami', description: WHOAMI_DESCRIPTION});


### PR DESCRIPTION
As a result running e.g. `juno config --help` printed undefined instead of the juno title.