### PR TITLE
fix: config command does not interpret mode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -124,7 +124,7 @@ export const run = async () => {
       await deploy(args);
       break;
     case 'config':
-      await config();
+      await config(args);
       break;
     case 'clear':
       await clear(args);


### PR DESCRIPTION
The `juno config --mode staging` was not interpreting the mode because, even though using the mode is implemented, the top level dispatcher of command did not pass the arguments 🤦‍♂️.