### PR TITLE
feat: pass metadata in mjs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@dfinity/identity": "^2.3.0",
         "@dfinity/principal": "^2.3.0",
         "@junobuild/admin": "^0.1.6",
-        "@junobuild/cli-tools": "^0.1.7-next-2025-04-05.2",
+        "@junobuild/cli-tools": "^0.1.7-next-2025-04-05.4",
         "@junobuild/config-loader": "^0.2.0",
         "@junobuild/core": "^0.1.9",
         "@junobuild/did-tools": "^0.2.0",
@@ -1475,9 +1475,9 @@
       }
     },
     "node_modules/@junobuild/cli-tools": {
-      "version": "0.1.7-next-2025-04-05.2",
-      "resolved": "https://registry.npmjs.org/@junobuild/cli-tools/-/cli-tools-0.1.7-next-2025-04-05.2.tgz",
-      "integrity": "sha512-i4Me5i1yhqLxCmoJI+U6NIjiznwiPmr58dglBJdXf6g40tQ48nvOSvkqwUFDDIBHNGSUIup/3WQzonfdlbkNrQ==",
+      "version": "0.1.7-next-2025-04-05.4",
+      "resolved": "https://registry.npmjs.org/@junobuild/cli-tools/-/cli-tools-0.1.7-next-2025-04-05.4.tgz",
+      "integrity": "sha512-AFBpTpwloLI37Cgw3rgPbI9GhMcy6laRyEXFkAjWkNiYkrOv4CURqVPivu0Vtf6zIuwgo9D76Z5usQq8hTWJfg==",
       "license": "MIT",
       "dependencies": {
         "file-type": "^20.4.1",
@@ -7918,9 +7918,9 @@
       "requires": {}
     },
     "@junobuild/cli-tools": {
-      "version": "0.1.7-next-2025-04-05.2",
-      "resolved": "https://registry.npmjs.org/@junobuild/cli-tools/-/cli-tools-0.1.7-next-2025-04-05.2.tgz",
-      "integrity": "sha512-i4Me5i1yhqLxCmoJI+U6NIjiznwiPmr58dglBJdXf6g40tQ48nvOSvkqwUFDDIBHNGSUIup/3WQzonfdlbkNrQ==",
+      "version": "0.1.7-next-2025-04-05.4",
+      "resolved": "https://registry.npmjs.org/@junobuild/cli-tools/-/cli-tools-0.1.7-next-2025-04-05.4.tgz",
+      "integrity": "sha512-AFBpTpwloLI37Cgw3rgPbI9GhMcy6laRyEXFkAjWkNiYkrOv4CURqVPivu0Vtf6zIuwgo9D76Z5usQq8hTWJfg==",
       "requires": {
         "file-type": "^20.4.1",
         "listr": "^0.14.3",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@dfinity/identity": "^2.3.0",
     "@dfinity/principal": "^2.3.0",
     "@junobuild/admin": "^0.1.6",
-    "@junobuild/cli-tools": "^0.1.7-next-2025-04-05.2",
+    "@junobuild/cli-tools": "^0.1.7-next-2025-04-05.4",
     "@junobuild/config-loader": "^0.2.0",
     "@junobuild/core": "^0.1.9",
     "@junobuild/did-tools": "^0.2.0",

--- a/src/constants/dev.constants.ts
+++ b/src/constants/dev.constants.ts
@@ -42,6 +42,3 @@ export const PACKAGE_JSON_PATH = join(process.cwd(), 'package.json');
 
 export const SPUTNIK_INDEX_MJS = 'sputnik.index.mjs';
 export const DEPLOY_SPUTNIK_PATH = join(DEPLOY_LOCAL_REPLICA_PATH, SPUTNIK_INDEX_MJS);
-
-export const SPUTNIK_PACKAGE_JSON = 'sputnik.package.json';
-export const PACKAGE_JSON_SPUTNIK_PATH = join(DEPLOY_LOCAL_REPLICA_PATH, SPUTNIK_PACKAGE_JSON);

--- a/src/services/build/build.javascript.ts
+++ b/src/services/build/build.javascript.ts
@@ -58,7 +58,7 @@ const buildWithEsbuild = async ({
 
   // We pass the package information as metadata so the Docker container can read it and embed it into the `juno:package` custom section of the WASM’s public metadata.
   const banner = {
-    js: `export const __juno_package__ = ${JSON.stringify(metadata)};`
+    js: `// @juno:package ${JSON.stringify(metadata)};`
   };
 
   const {metafile, errors, warnings, version} = await buildEsm({

--- a/src/services/build/build.javascript.ts
+++ b/src/services/build/build.javascript.ts
@@ -1,9 +1,9 @@
-import {isEmptyString, isNullish, notEmptyString} from '@dfinity/utils';
+import {isEmptyString, notEmptyString} from '@dfinity/utils';
 import {buildEsm, execute, type PackageJson} from '@junobuild/cli-tools';
 import type {Metafile} from 'esbuild';
 import {green, magenta, red, yellow} from 'kleur';
 import {existsSync} from 'node:fs';
-import {mkdir, writeFile} from 'node:fs/promises';
+import {mkdir} from 'node:fs/promises';
 import {join} from 'node:path';
 import {
   DEPLOY_LOCAL_REPLICA_PATH,
@@ -11,8 +11,7 @@ import {
   DEVELOPER_PROJECT_SATELLITE_PATH,
   INDEX_MJS,
   INDEX_TS,
-  PACKAGE_JSON_PATH,
-  PACKAGE_JSON_SPUTNIK_PATH
+  PACKAGE_JSON_PATH
 } from '../../constants/dev.constants';
 import type {BuildArgs, BuildLang} from '../../types/build';
 import {formatBytes, formatTime} from '../../utils/format.utils';
@@ -37,9 +36,7 @@ const build = async (params: BuildArgsTsJs) => {
 
   const metadata = await prepareMetadata();
 
-  await copyMetadata(metadata);
-
-  const buildResult = await buildWithEsbuild(params);
+  const buildResult = await buildWithEsbuild({params, metadata});
 
   printResults({metadata, buildResult});
 };
@@ -49,13 +46,25 @@ interface BuildResult {
   output: [string, Metafile['outputs'][0]];
 }
 
-const buildWithEsbuild = async ({lang, path}: BuildArgsTsJs): Promise<BuildResult> => {
+const buildWithEsbuild = async ({
+  params: {lang, path},
+  metadata
+}: {
+  params: BuildArgsTsJs;
+  metadata: BuildMetadata;
+}): Promise<BuildResult> => {
   const infile =
     path ?? join(DEVELOPER_PROJECT_SATELLITE_PATH, lang === 'mjs' ? INDEX_MJS : INDEX_TS);
 
+  // We pass the package information as metadata so the Docker container can read it and embed it into the `juno:package` custom section of the WASM’s public metadata.
+  const banner = {
+    js: `export const __juno_package__ = ${JSON.stringify(metadata)};`
+  };
+
   const {metafile, errors, warnings, version} = await buildEsm({
     infile,
-    outfile: DEPLOY_SPUTNIK_PATH
+    outfile: DEPLOY_SPUTNIK_PATH,
+    banner
   });
 
   for (const {text} of warnings) {
@@ -141,20 +150,6 @@ const prepareMetadata = async (): Promise<BuildMetadata> => {
     };
   } catch (_err: unknown) {
     console.log(red('⚠️ Could not read build metadata from package.json.'));
-    process.exit(1);
-  }
-};
-
-const copyMetadata = async (metadata: BuildMetadata): Promise<void> => {
-  if (isNullish(metadata)) {
-    // No metadata to pass to the build in the container.
-    return;
-  }
-
-  try {
-    await writeFile(PACKAGE_JSON_SPUTNIK_PATH, JSON.stringify(metadata, null, 2), 'utf-8');
-  } catch (_err: unknown) {
-    console.log(red('⚠️ Could not copy package.json metadata for the build.'));
     process.exit(1);
   }
 };


### PR DESCRIPTION
It's annoying and not synchrone to have to use a package.json to pass information from the client to the docker container so better let pass the info through the script. It's tiny.