### PR TITLE
fix: revert getting memory with the IC and use custom memory_size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@dfinity/ic-management": "^6.1.1",
         "@dfinity/identity": "^2.3.0",
         "@dfinity/principal": "^2.3.0",
-        "@junobuild/admin": "^0.3.1",
+        "@junobuild/admin": "^0.4.0",
         "@junobuild/cli-tools": "^0.1.9",
         "@junobuild/config": "^0.1.8",
         "@junobuild/config-loader": "^0.2.1",
@@ -1459,9 +1459,9 @@
       }
     },
     "node_modules/@junobuild/admin": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@junobuild/admin/-/admin-0.3.1.tgz",
-      "integrity": "sha512-ig0vxeSAInQM/4nFGIZUKgSI1Ln+aq1NWSSUIly8Jn0BswqUK+Y0Wuisq52CgCllT+JmBybS2DhsHiVm7TjFSg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@junobuild/admin/-/admin-0.4.0.tgz",
+      "integrity": "sha512-/2ehOn/CohJ7iybpueHzDt4Rq6vBCvKH3/CqRzRXyGiz+xq+/lsEi5ODN+QaUs6Td5DkxG2on/Pd9yxeIIcRnw==",
       "license": "MIT",
       "peerDependencies": {
         "@dfinity/agent": "^2.3.0",
@@ -8722,9 +8722,9 @@
       }
     },
     "@junobuild/admin": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@junobuild/admin/-/admin-0.3.1.tgz",
-      "integrity": "sha512-ig0vxeSAInQM/4nFGIZUKgSI1Ln+aq1NWSSUIly8Jn0BswqUK+Y0Wuisq52CgCllT+JmBybS2DhsHiVm7TjFSg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@junobuild/admin/-/admin-0.4.0.tgz",
+      "integrity": "sha512-/2ehOn/CohJ7iybpueHzDt4Rq6vBCvKH3/CqRzRXyGiz+xq+/lsEi5ODN+QaUs6Td5DkxG2on/Pd9yxeIIcRnw==",
       "requires": {}
     },
     "@junobuild/cli-tools": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@dfinity/ic-management": "^6.1.1",
         "@dfinity/identity": "^2.3.0",
         "@dfinity/principal": "^2.3.0",
-        "@junobuild/admin": "^0.3.0",
+        "@junobuild/admin": "^0.3.1",
         "@junobuild/cli-tools": "^0.1.9",
         "@junobuild/config": "^0.1.8",
         "@junobuild/config-loader": "^0.2.1",
@@ -1459,9 +1459,9 @@
       }
     },
     "node_modules/@junobuild/admin": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@junobuild/admin/-/admin-0.3.0.tgz",
-      "integrity": "sha512-o6uRdMu4WM0SoCJq9jPJAWy0oc5kBLWM9Hn02r3ZpFqeqqHOtscYtYMzwHKA7kmQn4yw48BP2116O1QMu3fBpw==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@junobuild/admin/-/admin-0.3.1.tgz",
+      "integrity": "sha512-ig0vxeSAInQM/4nFGIZUKgSI1Ln+aq1NWSSUIly8Jn0BswqUK+Y0Wuisq52CgCllT+JmBybS2DhsHiVm7TjFSg==",
       "license": "MIT",
       "peerDependencies": {
         "@dfinity/agent": "^2.3.0",
@@ -8722,9 +8722,9 @@
       }
     },
     "@junobuild/admin": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@junobuild/admin/-/admin-0.3.0.tgz",
-      "integrity": "sha512-o6uRdMu4WM0SoCJq9jPJAWy0oc5kBLWM9Hn02r3ZpFqeqqHOtscYtYMzwHKA7kmQn4yw48BP2116O1QMu3fBpw==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@junobuild/admin/-/admin-0.3.1.tgz",
+      "integrity": "sha512-ig0vxeSAInQM/4nFGIZUKgSI1Ln+aq1NWSSUIly8Jn0BswqUK+Y0Wuisq52CgCllT+JmBybS2DhsHiVm7TjFSg==",
       "requires": {}
     },
     "@junobuild/cli-tools": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@dfinity/ic-management": "^6.1.1",
     "@dfinity/identity": "^2.3.0",
     "@dfinity/principal": "^2.3.0",
-    "@junobuild/admin": "^0.3.0",
+    "@junobuild/admin": "^0.3.1",
     "@junobuild/cli-tools": "^0.1.9",
     "@junobuild/config": "^0.1.8",
     "@junobuild/config-loader": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@dfinity/ic-management": "^6.1.1",
     "@dfinity/identity": "^2.3.0",
     "@dfinity/principal": "^2.3.0",
-    "@junobuild/admin": "^0.3.1",
+    "@junobuild/admin": "^0.4.0",
     "@junobuild/cli-tools": "^0.1.9",
     "@junobuild/config": "^0.1.8",
     "@junobuild/config-loader": "^0.2.1",

--- a/src/services/deploy.services.ts
+++ b/src/services/deploy.services.ts
@@ -26,9 +26,7 @@ export const assertSatelliteMemorySize = async (args?: string[]) => {
       ? BigInt(assertions.heapMemory)
       : MEMORY_HEAP_WARNING;
 
-  const {
-    memory_metrics: {wasm_memory_size: heap}
-  } = await satelliteMemorySize({satellite});
+  const {heap} = await satelliteMemorySize({satellite});
 
   if (heap < maxMemorySize) {
     return;


### PR DESCRIPTION
We go back to before v0.3.0 where we used custom memory endpoints for the CLI. We need this to query the informaiton with controllers READ+WRITE in GH Actions.