### PR TITLE
feat: move juno dev build and eject to juno functions (breaking)

### DIFF
--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -1,10 +1,6 @@
 import {red} from 'kleur';
-import {logHelpDevBuild} from '../help/dev.build.help';
-import {logHelpDevEject} from '../help/dev.eject.help';
 import {logHelpDev} from '../help/dev.help';
 import {logHelpDevStart} from '../help/dev.start.help';
-import {build} from '../services/build/build.services';
-import {eject} from '../services/eject/eject.services';
 import {stop} from '../services/start/docker.services';
 import {start} from '../services/start/start.services';
 
@@ -12,12 +8,6 @@ export const dev = async (args?: string[]) => {
   const [subCommand] = args ?? [];
 
   switch (subCommand) {
-    case 'eject':
-      await eject(args);
-      break;
-    case 'build':
-      await build(args);
-      break;
     case 'start':
       await start(args);
       break;
@@ -26,7 +16,7 @@ export const dev = async (args?: string[]) => {
       break;
     default:
       console.log(red('Unknown subcommand.'));
-      logHelpDev();
+      logHelpDev(args);
   }
 };
 
@@ -36,12 +26,6 @@ export const helpDev = (args?: string[]) => {
   switch (subCommand) {
     case 'start':
       logHelpDevStart(args);
-      break;
-    case 'build':
-      logHelpDevBuild(args);
-      break;
-    case 'eject':
-      logHelpDevEject(args);
       break;
     default:
       logHelpDev(args);

--- a/src/commands/functions.ts
+++ b/src/commands/functions.ts
@@ -1,0 +1,37 @@
+import {red} from 'kleur';
+import {logHelpFunctionsBuild} from '../help/functions.build.help';
+import {logHelpFunctionsEject} from '../help/functions.eject.help';
+import {logHelpFunctions} from '../help/functions.help';
+import {build} from '../services/build/build.services';
+import {eject} from '../services/eject/eject.services';
+
+export const functions = async (args?: string[]) => {
+  const [subCommand] = args ?? [];
+
+  switch (subCommand) {
+    case 'eject':
+      await eject(args);
+      break;
+    case 'build':
+      await build(args);
+      break;
+    default:
+      console.log(red('Unknown subcommand.'));
+      logHelpFunctions(args);
+  }
+};
+
+export const helpFunctions = (args?: string[]) => {
+  const [subCommand] = args ?? [];
+
+  switch (subCommand) {
+    case 'build':
+      logHelpFunctionsBuild(args);
+      break;
+    case 'eject':
+      logHelpFunctionsEject(args);
+      break;
+    default:
+      logHelpFunctions(args);
+  }
+};

--- a/src/constants/help.constants.ts
+++ b/src/constants/help.constants.ts
@@ -6,7 +6,8 @@ export const CLEAR_DESCRIPTION =
 export const CONFIG_DESCRIPTION = 'Apply configuration to satellite.';
 export const DEPLOY_DESCRIPTION = 'Deploy your app to your satellite.';
 export const DEV_DESCRIPTION =
-  'Handle development tasks like building serverless functions or running a local Internet Computer instance.';
+  'Handle local development tasks like starting or stopping a local Internet Computer instance.';
+export const FUNCTIONS_DESCRIPTION = "Build and upgrade your satellite's serverless functions.";
 export const INIT_DESCRIPTION = 'Set up your project.';
 export const LOGIN_DESCRIPTION =
   'Generate an authentication for use in non-interactive environments.';
@@ -23,11 +24,12 @@ export const WHOAMI_DESCRIPTION =
   'Display your current profile, controller, and links to your satellite.';
 
 export const DEV_START_DESCRIPTION = 'Start a local Internet Computer network in a container.';
-export const DEV_BUILD_DESCRIPTION = 'Build your serverless functions.';
-export const DEV_EJECT_DESCRIPTION =
+
+export const FUNCTIONS_BUILD_DESCRIPTION = 'Build your serverless functions.';
+export const FUNCTIONS_EJECT_DESCRIPTION =
   'Generate the required files to begin developing serverless functions in your project.';
 
-export const DEV_BUILD_NOTES = `- If no language is provided, the CLI attempts to determine the appropriate build.
+export const FUNCTIONS_BUILD_NOTES = `- If no language is provided, the CLI attempts to determine the appropriate build.
 - Language can be shortened to ${magenta('rs')} for Rust, ${magenta('ts')} for TypeScript and ${magenta('mjs')} for JavaScript.
 - The path option maps to ${magenta('--manifest-path')} for Rust (Cargo) or to the source file for TypeScript and JavaScript (e.g. ${magenta('index.ts')} or ${magenta('index.mjs')}).
 - The watch option rebuilds when source files change, with a default debounce delay of 10 seconds; optionally, pass a delay in milliseconds.`;

--- a/src/help/dev.help.ts
+++ b/src/help/dev.help.ts
@@ -3,21 +3,10 @@ import {DEV_DESCRIPTION, DEV_START_DESCRIPTION} from '../constants/help.constant
 import {helpOutput} from './common.help';
 import {TITLE} from './help';
 
-const helpDevStart = `${magenta('start')}               ${DEV_START_DESCRIPTION}`;
-
-const helpDevBuild = `${magenta('build')}               Build your serverless functions. The local server supports live reloading.`;
-
-export const helpDevContinue = `${helpDevBuild}
-  ${helpDevStart}`;
-
 const usage = `Usage: ${green('juno')} ${cyan('dev')} ${magenta('<subcommand>')} ${yellow('[options]')}
 
 Subcommands:
-  ${helpDevBuild}
-  ${magenta(
-    'eject'
-  )}               Scaffold the necessary files to start coding and building functions in your project.
-  ${helpDevStart}
+  ${magenta('start')}               ${DEV_START_DESCRIPTION}
   ${magenta('stop')}                Stop the local network.`;
 
 const doc = `${DEV_DESCRIPTION}

--- a/src/help/dev.start.help.ts
+++ b/src/help/dev.start.help.ts
@@ -1,5 +1,9 @@
 import {cyan, green, magenta, yellow} from 'kleur';
-import {DEV_BUILD_NOTES, DEV_START_DESCRIPTION, OPTION_HELP} from '../constants/help.constants';
+import {
+  DEV_START_DESCRIPTION,
+  FUNCTIONS_BUILD_NOTES,
+  OPTION_HELP
+} from '../constants/help.constants';
 import {helpOutput} from './common.help';
 import {TITLE} from './help';
 
@@ -14,7 +18,7 @@ Options:
 Notes:
 
 - The language and path options are only used in combination with watch.
-${DEV_BUILD_NOTES}`;
+${FUNCTIONS_BUILD_NOTES}`;
 
 const doc = `${DEV_START_DESCRIPTION}
 

--- a/src/help/functions.build.help.ts
+++ b/src/help/functions.build.help.ts
@@ -1,9 +1,13 @@
 import {cyan, green, magenta, yellow} from 'kleur';
-import {DEV_BUILD_DESCRIPTION, DEV_BUILD_NOTES, OPTION_HELP} from '../constants/help.constants';
+import {
+  FUNCTIONS_BUILD_DESCRIPTION,
+  FUNCTIONS_BUILD_NOTES,
+  OPTION_HELP
+} from '../constants/help.constants';
 import {helpOutput} from './common.help';
 import {TITLE} from './help';
 
-const usage = `Usage: ${green('juno')} ${cyan('dev')} ${magenta('build')} ${yellow('[options]')}
+const usage = `Usage: ${green('juno')} ${cyan('functions')} ${magenta('build')} ${yellow('[options]')}
 
 Options:
   ${yellow('-l, --lang')}            Specify the language for building the serverless functions: ${magenta('rust')}, ${magenta('typescript')} or ${magenta('javascript')}.
@@ -13,9 +17,9 @@ Options:
   
 Notes:
 
-${DEV_BUILD_NOTES}`;
+${FUNCTIONS_BUILD_NOTES}`;
 
-const doc = `${DEV_BUILD_DESCRIPTION}
+const doc = `${FUNCTIONS_BUILD_DESCRIPTION}
 
 \`\`\`
 ${usage}
@@ -24,11 +28,11 @@ ${usage}
 
 const help = `${TITLE}
 
-${DEV_BUILD_DESCRIPTION}
+${FUNCTIONS_BUILD_DESCRIPTION}
 
 ${usage}
 `;
 
-export const logHelpDevBuild = (args?: string[]) => {
+export const logHelpFunctionsBuild = (args?: string[]) => {
   console.log(helpOutput(args) === 'doc' ? doc : help);
 };

--- a/src/help/functions.eject.help.ts
+++ b/src/help/functions.eject.help.ts
@@ -1,9 +1,9 @@
 import {cyan, green, magenta, yellow} from 'kleur';
-import {DEV_EJECT_DESCRIPTION, OPTION_HELP} from '../constants/help.constants';
+import {FUNCTIONS_EJECT_DESCRIPTION, OPTION_HELP} from '../constants/help.constants';
 import {helpOutput} from './common.help';
 import {TITLE} from './help';
 
-const usage = `Usage: ${green('juno')} ${cyan('dev')} ${magenta('eject')} ${yellow('[options]')}
+const usage = `Usage: ${green('juno')} ${cyan('functions')} ${magenta('eject')} ${yellow('[options]')}
 
 Options:
   ${yellow('-l, --lang')}            Specify the language for building the serverless functions: ${magenta('rust')}, ${magenta('typescript')} or ${magenta('javascript')}.
@@ -13,7 +13,7 @@ Notes:
 
 - Language can be shortened to ${magenta('rs')} for Rust, ${magenta('ts')} for TypeScript and ${magenta('mjs')} for JavaScript.`;
 
-const doc = `${DEV_EJECT_DESCRIPTION}
+const doc = `${FUNCTIONS_EJECT_DESCRIPTION}
 
 \`\`\`
 ${usage}
@@ -22,11 +22,11 @@ ${usage}
 
 const help = `${TITLE}
 
-${DEV_EJECT_DESCRIPTION}
+${FUNCTIONS_EJECT_DESCRIPTION}
 
 ${usage}
 `;
 
-export const logHelpDevEject = (args?: string[]) => {
+export const logHelpFunctionsEject = (args?: string[]) => {
   console.log(helpOutput(args) === 'doc' ? doc : help);
 };

--- a/src/help/functions.help.ts
+++ b/src/help/functions.help.ts
@@ -1,0 +1,33 @@
+import {cyan, green, magenta, yellow} from 'kleur';
+import {FUNCTIONS_DESCRIPTION} from '../constants/help.constants';
+import {helpOutput} from './common.help';
+import {TITLE} from './help';
+
+const usage = `Usage: ${green('juno')} ${cyan('functions')} ${magenta('<subcommand>')} ${yellow('[options]')}
+
+Subcommands:
+  ${magenta('build')}                Build your functions.
+  ${magenta('eject')}                Scaffold the necessary files for developing your serverless functions.
+  
+Notes:
+
+- The local server supports live reloading.
+- You can use ${cyan('fn')} as a shortcut for ${cyan('functions')}.`;
+
+const doc = `${FUNCTIONS_DESCRIPTION}
+
+\`\`\`
+${usage}
+\`\`\`
+`;
+
+const help = `${TITLE}
+
+${FUNCTIONS_DESCRIPTION}
+
+${usage}
+`;
+
+export const logHelpFunctions = (args?: string[]) => {
+  console.log(helpOutput(args) === 'doc' ? doc : help);
+};

--- a/src/help/help.ts
+++ b/src/help/help.ts
@@ -5,6 +5,7 @@ import {
   CONFIG_DESCRIPTION,
   DEPLOY_DESCRIPTION,
   DEV_DESCRIPTION,
+  FUNCTIONS_DESCRIPTION,
   INIT_DESCRIPTION,
   LOGIN_DESCRIPTION,
   LOGOUT_DESCRIPTION,
@@ -37,6 +38,7 @@ Commands:
   ${cyan('config')}              ${CONFIG_DESCRIPTION}
   ${cyan('deploy')}              ${DEPLOY_DESCRIPTION}
   ${cyan('dev')}                 ${DEV_DESCRIPTION}
+  ${cyan('functions')}           ${FUNCTIONS_DESCRIPTION}
   ${cyan('init')}                ${INIT_DESCRIPTION}
   ${cyan('help')}                Display help information.
   ${cyan('login')}               ${LOGIN_DESCRIPTION}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import {clear} from './commands/clear';
 import {config} from './commands/config';
 import {deploy} from './commands/deploy';
 import {dev, helpDev} from './commands/dev';
+import {functions, helpFunctions} from './commands/functions';
 import {init} from './commands/init';
 import {open} from './commands/open';
 import {snapshot} from './commands/snapshot';
@@ -83,6 +84,10 @@ export const run = async () => {
       case 'dev':
         helpDev(args);
         break;
+      case 'fn':
+      case 'functions':
+        helpFunctions(args);
+        break;
       case 'snapshot':
         logHelpSnapshot(args);
         break;
@@ -156,6 +161,10 @@ export const run = async () => {
       break;
     case 'dev':
       await dev(args);
+      break;
+    case 'fn':
+    case 'functions':
+      await functions(args);
       break;
     case 'snapshot':
       await snapshot(args);

--- a/src/services/eject/eject.services.ts
+++ b/src/services/eject/eject.services.ts
@@ -1,9 +1,8 @@
 import {notEmptyString} from '@dfinity/utils';
 import {assertAnswerCtrlC, nextArg} from '@junobuild/cli-tools';
-import {cyan, green, magenta, yellow} from 'kleur';
+import {yellow} from 'kleur';
 import prompts from 'prompts';
 import {DEVELOPER_PROJECT_SATELLITE_PATH} from '../../constants/dev.constants';
-import {helpDevContinue} from '../../help/dev.help';
 import {ejectJavaScript, ejectTypeScript} from './eject.javascript.services';
 import {ejectRust} from './eject.rust.services';
 
@@ -79,13 +78,6 @@ const selectLang = async (): Promise<{lang: Lang}> => {
 };
 
 export const success = (): string => `
-🚀 Satellite successfully ejected!
+✨ Functions initialized and good to go!
 
-The serverless function has been generated.
-You can now start coding in: ${yellow(DEVELOPER_PROJECT_SATELLITE_PATH)}
-
-Useful ${green('juno')} ${cyan('dev')} ${magenta('<subcommand>')} to continue with:
-
-Subcommands:
-  ${helpDevContinue}
-`;
+You can now start coding in: ${yellow(DEVELOPER_PROJECT_SATELLITE_PATH)}`;


### PR DESCRIPTION
# Motivation

A necessary breaking change which will allow for introducing `juno functions upgrade` because `juno upgrade --src ...` was suboptimal for upgrading functions anyways.