### PR TITLE
feat: run assert in headless

### DIFF
--- a/src/services/modules/upgrade/upgrade.services.ts
+++ b/src/services/modules/upgrade/upgrade.services.ts
@@ -31,8 +31,9 @@ const executeUpgradeWasm = async ({
   reset = false,
   assetKey
 }: {assetKey: AssetKey} & UpgradeWasm) => {
+  await assert?.({wasmModule: wasm});
+
   if (isNotHeadless()) {
-    await assert?.({wasmModule: wasm});
     await assertUpgradeHash({hash, reset});
   }
 


### PR DESCRIPTION
When upgrading in headless mode, even though we do not want to prompt the dev in this context, we still want to prevent serverless functions to being overwritten. Therefore we run the assertion and throw an error instead. Such an upgrade should be performed manually if really required.