### PR TITLE
fix: cargo metadata warning handled as errors and stopping process

### DIFF
--- a/src/services/functions/build/build.rust.services.ts
+++ b/src/services/functions/build/build.rust.services.ts
@@ -266,7 +266,8 @@ const extractBuildType = async ({path}: Pick<BuildArgs, 'path'> = {}): Promise<
   await spawn({
     command: 'cargo',
     args: ['metadata', '--format-version', '1', ...manifestArgs],
-    stdout: (o) => (output += o)
+    stdout: (o) => (output += o),
+    silentErrors: true
   });
 
   const metadata = JSON.parse(output);


### PR DESCRIPTION
Process is stopping unexpecly

```
An unexpected error happened 😫.

 Downloading crates ...
```
