### PR TITLE
chore: preserve cause of the error when reading token

### DIFF
--- a/src/utils/process.utils.ts
+++ b/src/utils/process.utils.ts
@@ -12,8 +12,10 @@ export const getProcessToken = (): JsonnableEd25519KeyIdentity | undefined => {
     const {token} = JSON.parse(atob(envToken));
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     return token;
-  } catch (_err: unknown) {
-    throw new Error('Cannot parse token provided as an environment variable.');
+  } catch (err: unknown) {
+    throw new Error('Cannot parse token provided as an environment variable.', {
+      cause: err
+    });
   }
 };
 


### PR DESCRIPTION
https://eslint.org/docs/latest/rules/preserve-caught-error