### PR TITLE
build: downgrade ic-mgmt to avoid issue with if field ready_for_migration is not available

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@dfinity/agent": "^3.2.4",
         "@dfinity/auth-client": "^3.2.4",
         "@dfinity/candid": "^3.2.4",
-        "@dfinity/ic-management": "^7.0.2",
+        "@dfinity/ic-management": "^7.0.1",
         "@dfinity/identity": "^3.2.4",
         "@dfinity/principal": "^3.2.4",
         "@dfinity/zod-schemas": "^1.1.0",
@@ -613,9 +613,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dfinity/ic-management": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-7.0.2.tgz",
-      "integrity": "sha512-NnWhB6LWMDUmWXzjc54my7XF6M7xoDL5AOY+i9wPTvnn1u2aJ2Nvme8B2nCk/VcXJ8fj4Y5JOtc08/oPwoI/nQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-7.0.1.tgz",
+      "integrity": "sha512-zatpUqzf9k3bYkLeikurwYXOwzvJgKf+y8+u1Vfb/cS58gOu4OMB2buc9/Rw5frtN9TRbe/vsTQSodnLLlbZIw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "^3",
@@ -6855,9 +6855,9 @@
       "integrity": "sha512-GPJpH73kDEKbUBdUjY80lz7cq9l0vm1h/7ppejPV6O0ZTqCLrYspssYvqjRmK4aNnJ/SKXsP0rg9LYX7zpegaA=="
     },
     "@dfinity/ic-management": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-7.0.2.tgz",
-      "integrity": "sha512-NnWhB6LWMDUmWXzjc54my7XF6M7xoDL5AOY+i9wPTvnn1u2aJ2Nvme8B2nCk/VcXJ8fj4Y5JOtc08/oPwoI/nQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-7.0.1.tgz",
+      "integrity": "sha512-zatpUqzf9k3bYkLeikurwYXOwzvJgKf+y8+u1Vfb/cS58gOu4OMB2buc9/Rw5frtN9TRbe/vsTQSodnLLlbZIw==",
       "requires": {}
     },
     "@dfinity/identity": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@dfinity/agent": "^3.2.4",
     "@dfinity/auth-client": "^3.2.4",
     "@dfinity/candid": "^3.2.4",
-    "@dfinity/ic-management": "^7.0.2",
+    "@dfinity/ic-management": "^7.0.1",
     "@dfinity/identity": "^3.2.4",
     "@dfinity/principal": "^3.2.4",
     "@dfinity/zod-schemas": "^1.1.0",


### PR DESCRIPTION
The new breaking change `ready_for_migration` should be available on mainnet but, not necessarly in the tooling. Therefore to avoid issue we downgrade the deps `@dfinity/ic-management` as the did files were updated in 7.0.1

Example of issue: https://github.com/junobuild/juno/actions/runs/17732129974/job/50385566632?pr=1940