### PR TITLE
feat: silence deprecation warnings for rust build

### DIFF
--- a/src/services/functions/build/build.rust.services.ts
+++ b/src/services/functions/build/build.rust.services.ts
@@ -86,7 +86,7 @@ export const buildRust = async ({
 
   const env = {
     ...process.env,
-    RUSTFLAGS: '--cfg getrandom_backend="custom"',
+    RUSTFLAGS: '--cfg getrandom_backend="custom" -A deprecated',
     ...(target === 'wasm32-wasip1' && {DEV_SCRIPT_PATH: DEPLOY_SPUTNIK_PATH})
   };
 


### PR DESCRIPTION
The deprecation warnings come from Juno and the cdk tooling so in the end, it's little the concern of the devs but more of Juno. This way it's less noisy.