### PR TITLE
refactor: rename and split rust build utils

### DIFF
--- a/src/services/functions/build/build.rust.services.ts
+++ b/src/services/functions/build/build.rust.services.ts
@@ -19,12 +19,8 @@ import {
   TARGET_PATH
 } from '../../../constants/dev.constants';
 import type {BuildArgs, BuildType} from '../../../types/build';
-import {
-  checkBindgen,
-  checkCandidExtractor,
-  checkIcWasm,
-  checkWasi2ic
-} from '../../../utils/build.rust.utils';
+import {checkIcpBindgen} from '../../../utils/build.bindgen.utils';
+import {checkCandidExtractor, checkIcWasm, checkWasi2ic} from '../../../utils/build.cargo.utils';
 import {readSatelliteDid} from '../../../utils/did.utils';
 import {checkRustVersion} from '../../../utils/env.utils';
 import {formatTime} from '../../../utils/format.utils';
@@ -56,7 +52,7 @@ export const buildRust = async ({
     return;
   }
 
-  const {valid: validBindgen} = await checkBindgen();
+  const {valid: validBindgen} = await checkIcpBindgen();
 
   if (!validBindgen) {
     return;

--- a/src/utils/build.bindgen.utils.ts
+++ b/src/utils/build.bindgen.utils.ts
@@ -1,0 +1,36 @@
+import {isNullish} from '@dfinity/utils';
+import {execute} from '@junobuild/cli-tools';
+import {magenta} from 'kleur';
+import {checkToolInstalled} from './env.utils';
+import {detectPackageManager} from './pm.utils';
+import {confirmAndExit} from './prompt.utils';
+
+export const checkIcpBindgen = async (): Promise<{valid: boolean}> => {
+  const pm = detectPackageManager();
+
+  const command = pm === 'npm' || isNullish(pm) ? 'npx' : pm;
+
+  const {valid} = await checkToolInstalled({
+    command,
+    args: ['icp-bindgen', '--version', ...(command === 'npx' ? ['--no'] : [])]
+  });
+
+  if (valid === false) {
+    return {valid};
+  }
+
+  if (valid === 'error') {
+    await confirmAndExit(
+      `${magenta(
+        '@icp-sdk/bindgen'
+      )} is not available. This tool is required to generate API bindings. Would you like to install it now?`
+    );
+
+    await execute({
+      command: pm ?? 'npm',
+      args: [pm === 'npm' ? 'i' : 'add', '@icp-sdk/bindgen', '-D']
+    });
+  }
+
+  return {valid: true};
+};

--- a/src/utils/build.cargo.utils.ts
+++ b/src/utils/build.cargo.utils.ts
@@ -1,9 +1,7 @@
-import {isNullish} from '@dfinity/utils';
 import {execute} from '@junobuild/cli-tools';
 import {magenta, yellow} from 'kleur';
 import {IC_WASM_MIN_VERSION} from '../constants/dev.constants';
 import {checkIcWasmVersion, checkToolInstalled} from './env.utils';
-import {detectPackageManager} from './pm.utils';
 import {confirmAndExit} from './prompt.utils';
 
 export const checkIcWasm = async (): Promise<{valid: boolean}> => {
@@ -49,36 +47,6 @@ export const checkCandidExtractor = async (): Promise<{valid: boolean}> => {
     await execute({
       command: 'cargo',
       args: ['install', 'candid-extractor']
-    });
-  }
-
-  return {valid: true};
-};
-
-export const checkBindgen = async (): Promise<{valid: boolean}> => {
-  const pm = detectPackageManager();
-
-  const command = pm === 'npm' || isNullish(pm) ? 'npx' : pm;
-
-  const {valid} = await checkToolInstalled({
-    command,
-    args: ['icp-bindgen', '--version', ...(command === 'npx' ? ['--no'] : [])]
-  });
-
-  if (valid === false) {
-    return {valid};
-  }
-
-  if (valid === 'error') {
-    await confirmAndExit(
-      `${magenta(
-        '@icp-sdk/bindgen'
-      )} is not available. This tool is required to generate API bindings. Would you like to install it now?`
-    );
-
-    await execute({
-      command: pm ?? 'npm',
-      args: [pm === 'npm' ? 'i' : 'add', '@icp-sdk/bindgen', '-D']
     });
   }
 


### PR DESCRIPTION
We will need to add more logic for bindgen to fallback on global npm in headless if no local lib is available. So let's split the code.