### PR TITLE
fix: password question hided behind spinner on download snapshot

### DIFF
--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -17,8 +17,8 @@ import type {AssetKey} from '../types/asset-key';
 import {toAssetKeys} from '../utils/asset-key.utils';
 import {orbiterKey, satelliteKey} from '../utils/cli.config.utils';
 import {
-  assertConfigAndLoadSatelliteContext,
-  assertConfigAndReadOrbiterId
+  assertConfigAndLoadOrbiterContext,
+  assertConfigAndLoadSatelliteContext
 } from '../utils/juno.config.utils';
 import {lastRelease} from '../utils/upgrade.utils';
 
@@ -96,9 +96,9 @@ const satelliteVersion = async () => {
 };
 
 const orbitersVersion = async () => {
-  const {orbiterId} = await assertConfigAndReadOrbiterId();
+  const orbiter = await assertConfigAndLoadOrbiterContext();
 
-  if (isNullish(orbiterId)) {
+  if (isNullish(orbiter)) {
     return;
   }
 
@@ -136,6 +136,10 @@ const orbitersVersion = async () => {
       displayHint
     });
   };
+
+  const {
+    orbiter: {orbiterId}
+  } = orbiter;
 
   await checkOrbiterVersion(orbiterId);
 };

--- a/src/services/modules/snapshot/snapshot.orbiter.services.ts
+++ b/src/services/modules/snapshot/snapshot.orbiter.services.ts
@@ -1,6 +1,6 @@
 import {isNullish} from '@dfinity/utils';
 import type {AssetKey} from '../../../types/asset-key';
-import {assertConfigAndReadOrbiterId} from '../../../utils/juno.config.utils';
+import {assertConfigAndLoadOrbiterContext} from '../../../utils/juno.config.utils';
 import {
   createSnapshot,
   deleteSnapshot,
@@ -53,11 +53,15 @@ const executeSnapshotFn = async ({
 }: {
   fn: (params: {canisterId: string; segment: AssetKey}) => Promise<void>;
 }) => {
-  const {orbiterId} = await assertConfigAndReadOrbiterId();
+  const orbiter = await assertConfigAndLoadOrbiterContext();
 
-  if (isNullish(orbiterId)) {
+  if (isNullish(orbiter)) {
     return;
   }
+
+  const {
+    orbiter: {orbiterId}
+  } = orbiter;
 
   await fn({
     canisterId: orbiterId,

--- a/src/services/modules/start-stop.services.ts
+++ b/src/services/modules/start-stop.services.ts
@@ -7,8 +7,8 @@ import {getCliMissionControl} from '../../configs/cli.config';
 import type {AssetKey} from '../../types/asset-key';
 import type {StartStopAction} from '../../types/start-stop';
 import {
-  assertConfigAndLoadSatelliteContext,
-  assertConfigAndReadOrbiterId
+  assertConfigAndLoadOrbiterContext,
+  assertConfigAndLoadSatelliteContext
 } from '../../utils/juno.config.utils';
 
 export const startStopMissionControl = async ({
@@ -32,11 +32,15 @@ export const startStopMissionControl = async ({
 };
 
 export const startStopOrbiter = async ({action}: {args?: string[]; action: StartStopAction}) => {
-  const {orbiterId} = await assertConfigAndReadOrbiterId();
+  const orbiter = await assertConfigAndLoadOrbiterContext();
 
-  if (isNullish(orbiterId)) {
+  if (isNullish(orbiter)) {
     return;
   }
+
+  const {
+    orbiter: {orbiterId}
+  } = orbiter;
 
   await startStop({
     action,

--- a/src/services/modules/upgrade/upgrade.orbiter.services.ts
+++ b/src/services/modules/upgrade/upgrade.orbiter.services.ts
@@ -8,7 +8,7 @@ import {actorParameters} from '../../../api/actor.api';
 import {ORBITER_WASM_NAME} from '../../../constants/constants';
 import type {UpgradeWasmModule} from '../../../types/upgrade';
 import {orbiterKey} from '../../../utils/cli.config.utils';
-import {assertConfigAndReadOrbiterId} from '../../../utils/juno.config.utils';
+import {assertConfigAndLoadOrbiterContext} from '../../../utils/juno.config.utils';
 import {NEW_CMD_LINE} from '../../../utils/prompt.utils';
 import {logUpgradeResult, readUpgradeOptions} from '../../../utils/upgrade.utils';
 import {
@@ -21,9 +21,9 @@ import {
 type Orbiter = Omit<OrbiterParameters, 'orbiterId'> & {orbiterId: PrincipalText};
 
 export const upgradeOrbiters = async (args?: string[]) => {
-  const {orbiterId} = await assertConfigAndReadOrbiterId();
+  const orbiter = await assertConfigAndLoadOrbiterContext();
 
-  if (isNullish(orbiterId)) {
+  if (isNullish(orbiter)) {
     return;
   }
 
@@ -50,6 +50,10 @@ export const upgradeOrbiters = async (args?: string[]) => {
 
     logResult(result);
   };
+
+  const {
+    orbiter: {orbiterId}
+  } = orbiter;
 
   await upgradeOrbiter(orbiterId);
 };

--- a/src/types/satellite.ts
+++ b/src/types/satellite.ts
@@ -1,6 +1,10 @@
 import type {PrincipalText} from '@dfinity/zod-schemas';
-import type {SatelliteParameters} from '@junobuild/ic-client/actor';
+import type {OrbiterParameters, SatelliteParameters} from '@junobuild/ic-client/actor';
 
 export type SatelliteParametersWithId = Omit<SatelliteParameters, 'satelliteId'> & {
   satelliteId: PrincipalText;
+};
+
+export type OrbiterParametersWithId = Omit<OrbiterParameters, 'orbiterId'> & {
+  orbiterId: PrincipalText;
 };


### PR DESCRIPTION
Follow-up of #425 which I did not detected when I tested the feature because I was testing locally (`--mode development`) without encoded CLI config, without password (local emulator). Later, when I tried to download a snapshot for an Orbiter on prod, I couldn't because the CLI was requesting the pwd while a spinner is displayed and those disallow any keyboard interaction 🥲.